### PR TITLE
Fix compilation error by some C++20 compilers.

### DIFF
--- a/pem-com.cpp
+++ b/pem-com.cpp
@@ -74,7 +74,7 @@ SecByteBlock GetControlFieldData(const SecByteBlock& line)
     return SecByteBlock();
 }
 
-struct ByteToLower : public std::unary_function<byte, byte> {
+struct ByteToLower {
     byte operator() (byte val) {
         return (byte)std::tolower((int)(word32)val);
     }


### PR DESCRIPTION
`std::unary_function` was removed in C++20. Since it may be required only by function object adapters such as `std::not1`, base class should not matter in this case.