### PR TITLE
Fix size_t underflow in binary search in x509cert processing

### DIFF
--- a/x509cert.cpp
+++ b/x509cert.cpp
@@ -262,9 +262,9 @@ std::string OidToNameLookup(const OID& oid, const char *defaultName)
     static const OidToNameArray table = GetOidToNameTable();
 
     // Binary search
-    size_t first  = 0;
-    size_t last   = table.size() - 1;
-    size_t middle = (first+last)/2;
+    int first  = 0;
+    int last   = table.size() - 1;
+    int middle = (first+last)/2;
 
     while (first <= last)
     {
@@ -344,9 +344,9 @@ KeyUsageValue::KeyUsageEnum OidToKeyUsageValueLookup(const OID& oid, KeyUsageVal
     static const OidToKeyUsageValueArray table = GetOidToKeyUsageValueTable();
 
     // Binary search
-    size_t first  = 0;
-    size_t last   = table.size() - 1;
-    size_t middle = (first+last)/2;
+    int first  = 0;
+    int last   = table.size() - 1;
+    int middle = (first+last)/2;
 
     while (first <= last)
     {


### PR DESCRIPTION
The original code used `size_t` for `first`,`last` & `middle` sentinels in a binary search algorithm when looking up OIDs in a table in the OidToNameLookup & OidToKeyUsageValueLookup functions.

If an OID which came before all of the entries in the table was looked up eventually the `last` sentinel would be decreased to -1 and the search should have ended, as the condition `first <= last` should have failed. However, since an unsigned type (`size_t`) was used for the sentinels, decreasing `last` to -1 underflowed it and the code subsequently crashed.