### PR TITLE
Rename the misleadingly named method GetSubjecPublicKeyAlgorithm.

### DIFF
--- a/x509cert.h
+++ b/x509cert.h
@@ -621,7 +621,12 @@ public:
     /// \brief Subject public key algorithm
     /// \returns Subject public key algorithm
     /// \sa GetSubjectPublicKey
-    const OID& GetSubjectPublicKeyAlgorithm() const
+    OID GetSubjectPublicKeyAlgorithm() const
+        { return m_subjectPublicKey->GetAlgorithmID(); }
+
+    /// \brief Subject signature algorithm
+    /// \returns Subject signature algorithm
+    const OID& GetSubjectSignatureAlgorithm() const
         { return m_subjectSignatureAlgortihm; }
 
     /// \brief Subject public key


### PR DESCRIPTION
The method name indicated that it would return the algorithm of the public key that is signed by the certificate. Instead it returned the algorithm used to sign the public key. The current commit changes it return the OID of the public key algorithm and adds a new method, GetSubjectSignatureAlgorithm, to retrieve the information that was originally returned --- the signature algorithm.